### PR TITLE
Extend lokalise with export empty parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Parameters:
 - `languages`. Languages to download *(must be passed as array of strings, leave empty to download all)*.
 - `include_comments`. Include comments in exported files.
 - `use_original`. Use original filenames/formats.
-- `export_empty `. How to export empty strings. Available options: `empty`, `base`, `skip`. Default value: `base`.
+- `export_empty`. How to export empty strings. Allowed values: `empty`, `base`, `skip`. Default value: `base`.
+- `export_sort`. Export key sort mode. Allowed values: 'first_added', 'last_added', 'last_updated', 'a_z', 'z_a'. Default value: `a_z`.
 
 ## lokalise_metadata
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Parameters:
 - `languages`. Languages to download *(must be passed as array of strings, leave empty to download all)*.
 - `include_comments`. Include comments in exported files.
 - `use_original`. Use original filenames/formats.
+- `export_empty `. How to export empty strings. Available options: `empty`, `base`, `skip`. Default value: `base`.
 
 ## lokalise_metadata
 

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -11,6 +11,7 @@ module Fastlane
         include_comments = params[:include_comments] ? 1 : 0
         use_original = params[:use_original] ? 1 : 0
         export_empty = params[:export_empty]
+        export_sort = params[:export_sort]
 
         request_data = {
           api_token: token,
@@ -21,7 +22,8 @@ module Fastlane
           bundle_structure: "%LANG_ISO%.lproj/Localizable.%FORMAT%",
           ota_plugin_bundle: 0,
           export_empty: export_empty,
-          include_comments: include_comments
+          include_comments: include_comments,
+          export_sort: = export_sort
         }
 
         languages = params[:languages]
@@ -153,6 +155,14 @@ module Fastlane
                                        default_value: "base",
                                        verify_block: proc do |value|
                                          UI.user_error! "Use one of options: empty, base, skip." unless ['empty', 'base', 'skip'].include?(value)
+                                        end),
+            FastlaneCore::ConfigItem.new(key: :export_sort,
+                                       description: "Export key sort mode",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: "last_updated",
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Use one of options: first_added, last_added, last_updated, a_z, z_a." unless ['first_added', 'last_added', 'last_updated', 'a_z', 'z_a'].include?(value)
                                         end)
         ]
       end

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -10,6 +10,7 @@ module Fastlane
         clean_destination = params[:clean_destination]
         include_comments = params[:include_comments] ? 1 : 0
         use_original = params[:use_original] ? 1 : 0
+        export_empty = params[:export_empty]
 
         request_data = {
           api_token: token,
@@ -19,7 +20,7 @@ module Fastlane
           bundle_filename: "Localization.zip",
           bundle_structure: "%LANG_ISO%.lproj/Localizable.%FORMAT%",
           ota_plugin_bundle: 0,
-          export_empty: "base",
+          export_empty: export_empty,
           include_comments: include_comments
         }
 
@@ -35,7 +36,6 @@ module Fastlane
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
         response = http.request(request)
-
 
         jsonResponse = JSON.parse(response.body)
         UI.error "Bad response 🉐\n#{response.body}" unless jsonResponse.kind_of? Hash
@@ -68,7 +68,6 @@ module Fastlane
         end
       end
 
-
       def self.unzip_file(file, destination, clean_destination)
         require 'zip'
         require 'rubygems'
@@ -87,7 +86,6 @@ module Fastlane
            }
         }
       end
-
 
       #####################################################
       # @!group Documentation
@@ -147,6 +145,14 @@ module Fastlane
                                        default_value: false,
                                        verify_block: proc do |value|
                                          UI.user_error! "Use original should be true of false." unless [true, false].include?(value)
+                                        end),
+            FastlaneCore::ConfigItem.new(key: :export_empty,
+                                       description: "How to export empty strings",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: "base",
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Use one of options: empty, base, skip." unless ['empty', 'base', 'skip'].include?(value)
                                         end)
         ]
       end

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -23,7 +23,7 @@ module Fastlane
           ota_plugin_bundle: 0,
           export_empty: export_empty,
           include_comments: include_comments,
-          export_sort: = export_sort
+          export_sort: export_sort
         }
 
         languages = params[:languages]
@@ -160,7 +160,7 @@ module Fastlane
                                        description: "Export key sort mode",
                                        optional: true,
                                        is_string: true,
-                                       default_value: "last_updated",
+                                       default_value: "a_z",
                                        verify_block: proc do |value|
                                          UI.user_error! "Use one of options: first_added, last_added, last_updated, a_z, z_a." unless ['first_added', 'last_added', 'last_updated', 'a_z', 'z_a'].include?(value)
                                         end)


### PR DESCRIPTION
- [x] add additional `export_empty` parameter to lokalise.rb
- [x] fix formatting