### PR TITLE
Add tags option to LokaliseAction

### DIFF
--- a/lokalise.rb
+++ b/lokalise.rb
@@ -36,6 +36,7 @@ module Fastlane
         http.use_ssl = true
         response = http.request(request)
 
+
         jsonResponse = JSON.parse(response.body)
         UI.error "Bad response 🉐\n#{response.body}" unless jsonResponse.kind_of? Hash
         if jsonResponse["response"]["status"] == "success" && jsonResponse["bundle"]["file"].kind_of?(String)  then
@@ -49,7 +50,7 @@ module Fastlane
           response = http.request(zipRequest)
           if response.content_type == "application/zip" or response.content_type == "application/octet-stream" then
             FileUtils.mkdir_p("lokalisetmp")
-            open("lokalisetmp/a.zip", "wb") { |file|
+            open("lokalisetmp/a.zip", "wb") { |file| 
               file.write(response.body)
             }
             unzip_file("lokalisetmp/a.zip", destination, clean_destination)
@@ -155,7 +156,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        [:ios, :mac].include? platform 
       end
     end
   end

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -36,7 +36,6 @@ module Fastlane
         http.use_ssl = true
         response = http.request(request)
 
-
         jsonResponse = JSON.parse(response.body)
         UI.error "Bad response 🉐\n#{response.body}" unless jsonResponse.kind_of? Hash
         if jsonResponse["response"]["status"] == "success" && jsonResponse["bundle"]["file"].kind_of?(String)  then
@@ -50,7 +49,7 @@ module Fastlane
           response = http.request(zipRequest)
           if response.content_type == "application/zip" or response.content_type == "application/octet-stream" then
             FileUtils.mkdir_p("lokalisetmp")
-            open("lokalisetmp/a.zip", "wb") { |file| 
+            open("lokalisetmp/a.zip", "wb") { |file|
               file.write(response.body)
             }
             unzip_file("lokalisetmp/a.zip", destination, clean_destination)
@@ -156,7 +155,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform 
+        [:ios, :mac].include? platform
       end
     end
   end

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -28,6 +28,11 @@ module Fastlane
           request_data["langs"] = languages.to_json
         end
 
+        tags = params[:tags]
+        if tags.kind_of? Array then
+          request_data["include_tags"] = tags.to_json
+        end
+
         uri = URI("https://api.lokalise.co/api/project/export")
         request = Net::HTTP::Post.new(uri)
         request.set_form_data(request_data)
@@ -147,7 +152,15 @@ module Fastlane
                                        default_value: false,
                                        verify_block: proc do |value|
                                          UI.user_error! "Use original should be true of false." unless [true, false].include?(value)
-                                        end)
+                                        end),
+            FastlaneCore::ConfigItem.new(key: :tags,
+                                        description: "Include only the keys tagged with a given set of tags",
+                                        optional: true,
+                                        is_string: false,
+                                        verify_block: proc do |value|
+                                          UI.user_error! "Tags should be passed as array" unless value.kind_of? Array
+                                        end),
+
         ]
       end
 


### PR DESCRIPTION
In this PR, the `LokaliseAction` is extended to support the `tags` option. When this option is passed to the fastlane action, the `--include_tags` is used when fetching the keys.
