### PR TITLE
Introduced :bundle_structure, :export_sort, and :replace_breaks parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Parameters:
 - `languages`. Languages to download *(must be passed as array of strings, leave empty to download all)*.
 - `include_comments`. Include comments in exported files.
 - `use_original`. Use original filenames/formats.
+- `tags`. Include only the keys tagged with a given set of tags.
+- `bundle_structure`. Bundle structure, used when original_filenames set to false. Allowed placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%).
+- `export_sort`. Export key sort mode. Allowed values are `first_added`, `last_added`, `last_updated`, `a_z`, `z_a`.
+- `replace_breaks`. Replace breaks.
 
 ## lokalise_metadata
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Parameters:
 - `include_comments`. Include comments in exported files.
 - `use_original`. Use original filenames/formats.
 - `tags`. Include only the keys tagged with a given set of tags.
-- `bundle_structure`. Bundle structure, used when original_filenames set to false. Allowed placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%).
+- `bundle_structure`. Bundle structure, used when original_filenames set to false. Allowed placeholders are `%LANG_ISO%`, `%LANG_NAME%`, `%FORMAT%` and `%PROJECT_NAME%`.
 - `export_sort`. Export key sort mode. Allowed values are `first_added`, `last_added`, `last_updated`, `a_z`, `z_a`.
 - `replace_breaks`. Replace breaks.
 

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -10,16 +10,19 @@ module Fastlane
         clean_destination = params[:clean_destination]
         include_comments = params[:include_comments]
         original_filenames = params[:use_original]
+        bundle_structure = params[:bundle_structure] ? params[:bundle_structure] : "%LANG_ISO%.lproj/Localizable.%FORMAT%"
+        export_sort = params[:export_sort] ? params[:export_sort] : "a_z"
+        replace_breaks = params[:replace_breaks] ? true : false
 
         body = {
           format: "ios_sdk",
           original_filenames: original_filenames,
           bundle_filename: "Localization.zip",
-          bundle_structure: "%LANG_ISO%.lproj/Localizable.%FORMAT%",
+          bundle_structure: bundle_structure,
           export_empty_as: "base",
-          export_sort: "first_added",
+          export_sort: export_sort,
           include_comments: include_comments,
-          replace_breaks: false
+          replace_breaks: replace_breaks
         }
 
         filter_langs = params[:languages]
@@ -83,12 +86,12 @@ module Fastlane
             FileUtils.mkdir_p(destination)
           end
           UI.message "Unarchiving localizations to destination 📚"
-           zip_file.each { |f|
-             f_path= File.join(destination, f.name)
-             FileUtils.mkdir_p(File.dirname(f_path))
-             FileUtils.rm(f_path) if File.file? f_path
-             zip_file.extract(f, f_path)
-           }
+          zip_file.each { |f|
+            f_path= File.join(destination, f.name)
+            FileUtils.mkdir_p(File.dirname(f_path))
+            FileUtils.rm(f_path) if File.file? f_path
+            zip_file.extract(f, f_path)
+          }
         }
       end
 
@@ -104,62 +107,83 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :api_token,
-                                       env_name: "LOKALISE_API_TOKEN",
-                                       description: "API Token for Lokalise",
-                                       verify_block: proc do |value|
-                                          UI.user_error! "No API token for Lokalise given, pass using `api_token: 'token'`" unless (value and not value.empty?)
-                                       end),
+                                      env_name: "LOKALISE_API_TOKEN",
+                                      description: "API Token for Lokalise",
+                                      verify_block: proc do |value|
+                                        UI.user_error! "No API token for Lokalise given, pass using `api_token: 'token'`" unless (value and not value.empty?)
+                                      end),
           FastlaneCore::ConfigItem.new(key: :project_identifier,
-                                       env_name: "LOKALISE_PROJECT_ID",
-                                       description: "Lokalise Project ID",
-                                       verify_block: proc do |value|
-                                          UI.user_error! "No Project Identifier for Lokalise given, pass using `project_identifier: 'identifier'`" unless (value and not value.empty?)
-                                       end),
+                                      env_name: "LOKALISE_PROJECT_ID",
+                                      description: "Lokalise Project ID",
+                                      verify_block: proc do |value|
+                                        UI.user_error! "No Project Identifier for Lokalise given, pass using `project_identifier: 'identifier'`" unless (value and not value.empty?)
+                                      end),
           FastlaneCore::ConfigItem.new(key: :destination,
-                                       description: "Localization destination",
-                                       verify_block: proc do |value|
-                                          UI.user_error! "Things are pretty bad" unless (value and not value.empty?)
-                                          UI.user_error! "Directory you passed is in your imagination" unless File.directory?(value)
-                                       end),
+                                      description: "Localization destination",
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Things are pretty bad" unless (value and not value.empty?)
+                                        UI.user_error! "Directory you passed is in your imagination" unless File.directory?(value)
+                                      end),
           FastlaneCore::ConfigItem.new(key: :clean_destination,
-                                       description: "Clean destination folder",
-                                       optional: true,
-                                       is_string: false,
-                                       default_value: false,
-                                       verify_block: proc do |value|
-                                          UI.user_error! "Clean destination should be true or false" unless [true, false].include? value
-                                       end),
+                                      description: "Clean destination folder",
+                                      optional: true,
+                                      is_string: false,
+                                      default_value: false,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Clean destination should be true or false" unless [true, false].include? value
+                                      end),
           FastlaneCore::ConfigItem.new(key: :languages,
-                                       description: "Languages to download",
-                                       optional: true,
-                                       is_string: false,
-                                       verify_block: proc do |value|
-                                          UI.user_error! "Language codes should be passed as array" unless value.kind_of? Array
-                                       end),
-            FastlaneCore::ConfigItem.new(key: :include_comments,
-                                       description: "Include comments in exported files",
-                                       optional: true,
-                                       is_string: false,
-                                       default_value: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error! "Include comments should be true or false" unless [true, false].include? value
-                                       end),
-            FastlaneCore::ConfigItem.new(key: :use_original,
-                                       description: "Use original filenames/formats (bundle_structure parameter is ignored then)",
-                                       optional: true,
-                                       is_string: false,
-                                       default_value: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error! "Use original should be true of false." unless [true, false].include?(value)
-                                        end),
-            FastlaneCore::ConfigItem.new(key: :tags,
-                                        description: "Include only the keys tagged with a given set of tags",
-                                        optional: true,
-                                        is_string: false,
-                                        verify_block: proc do |value|
-                                          UI.user_error! "Tags should be passed as array" unless value.kind_of? Array
-                                        end),
-
+                                      description: "Languages to download",
+                                      optional: true,
+                                      is_string: false,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Language codes should be passed as array" unless value.kind_of? Array
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :include_comments,
+                                      description: "Include comments in exported files",
+                                      optional: true,
+                                      is_string: false,
+                                      default_value: false,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Include comments should be true or false" unless [true, false].include? value
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :use_original,
+                                      description: "Use original filenames/formats (bundle_structure parameter is ignored then)",
+                                      optional: true,
+                                      is_string: false,
+                                      default_value: false,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Use original should be true of false." unless [true, false].include?(value)
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :tags,
+                                      description: "Include only the keys tagged with a given set of tags",
+                                      optional: true,
+                                      is_string: false,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Tags should be passed as array" unless value.kind_of? Array
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :bundle_structure,
+                                      description: "Bundle structure, used when original_filenames set to false. Allowed placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%)",
+                                      optional: true,
+                                      is_string: true,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Should be a String" unless value.kind_of? String
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :export_sort,
+                                      description: "Export key sort mode. Allowed values are first_added, last_added, last_updated, a_z, z_a",
+                                      optional: true,
+                                      is_string: true,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Should be a String" unless value.kind_of? String
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :replace_breaks,
+                                      description: "Replace breaks",
+                                      optional: true,
+                                      is_string: false,
+                                      default_value: false,
+                                      verify_block: proc do |value|
+                                        UI.user_error! "Replace break should be true or false" unless [true, false].include? value
+                                      end),
         ]
       end
 

--- a/lokalise.rb
+++ b/lokalise.rb
@@ -11,7 +11,7 @@ module Fastlane
         include_comments = params[:include_comments]
         original_filenames = params[:use_original]
         bundle_structure = params[:bundle_structure] ? params[:bundle_structure] : "%LANG_ISO%.lproj/Localizable.%FORMAT%"
-        export_sort = params[:export_sort] ? params[:export_sort] : "a_z"
+        export_sort = params[:export_sort] ? params[:export_sort] : "first_added"
         replace_breaks = params[:replace_breaks] ? true : false
 
         body = {
@@ -163,7 +163,7 @@ module Fastlane
                                         UI.user_error! "Tags should be passed as array" unless value.kind_of? Array
                                       end),
           FastlaneCore::ConfigItem.new(key: :bundle_structure,
-                                      description: "Bundle structure, used when original_filenames set to false. Allowed placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%)",
+                                      description: "Bundle structure, used when original_filenames set to false. Allowed placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%",
                                       optional: true,
                                       is_string: true,
                                       verify_block: proc do |value|


### PR DESCRIPTION
This PR introduces the `:bundle_structure`, `:export_sort`, and `:replace_breaks` parameters for the lokalise download action.

Special thanks to @NicolasLourenco for [his PR from 2019](https://github.com/lokalise/lokalise-fastlane-actions/pull/13), which I updated with the latest changes.