### PR TITLE
feat: add support special placeholder `[VOID]`

### DIFF
--- a/lokalise_metadata.rb
+++ b/lokalise_metadata.rb
@@ -95,7 +95,9 @@ module Fastlane
             metadata.each do |lang, translations|
               if !translations.empty?
                 translation = translations[key]
-                final_translations[lang] = translation if !translation.nil? && !translation.empty?
+                if !translation.nil? && !translation.empty?
+                  final_translations[lang] = translation == '[VOID]' ? ' ' : translation
+                end
               end
             end
 
@@ -125,7 +127,9 @@ module Fastlane
             metadata.each do |lang, translations|
               if !translations.empty?
                 translation = translations[key]
-                final_translations[lang] = translation if !translation.nil? && !translation.empty?
+                if !translation.nil? && !translation.empty?
+                  final_translations[lang] = translation == '[VOID]' ? ' ' : translation
+                end
               end
             end
 


### PR DESCRIPTION
When existing & in-use translation text is replaced with an empty string to remove the translation text,
the text is not actually removed because it gets filtered out by the translation check logic.
Adding support for the special placeholder `[VOID]` allows the text to be removed.

If translation text is `"[VOID]"`, replace it with `" "`.
Because the empty string is filtered out inside the deliverer, the translation text change is not reflected.